### PR TITLE
Get rid of undefined vars errors

### DIFF
--- a/templates/included.conf.j2
+++ b/templates/included.conf.j2
@@ -27,14 +27,17 @@ zone "{{ key | regex_replace('_', '.') }}" {
 {% if value.type == 'master' %}
     file "/var/named/masters/{{ key | regex_replace('_', '.') }}.zone";
     allow-update { none; };
+{% if value.allow_transfer is defined %}
     allow-transfer {
     {% for key in value.allow_transfer %}
     {{ key }};
     {% endfor %}
+{% endif %}
+{% if value.allow_notify is defined %}
     {% for key in value.allow_notify %}
     {{ key }};
     {% endfor %}
-};
+{% endif %}
 {% elif value.type == 'slave' %}
     file "/var/named/slaves/{{ key | regex_replace('_', '.') }}.zone";
     masters { {{ value.master }}; };


### PR DESCRIPTION
I think that forcing ansible users to set error_on_undefined_vars=False is not best practice.
